### PR TITLE
making test suite run to completion

### DIFF
--- a/test/t2.js
+++ b/test/t2.js
@@ -9,4 +9,4 @@ var trial = new Trial({ verbose: process.env.VERBOSE });
 trial.add(t1);
 trial.run();
 
-setTimeout(function() { process.kill(0, 'SIGINT'); }, 2000);
+setTimeout(function() { process.kill(process.pid, 'SIGINT'); }, 2000);


### PR DESCRIPTION
Using process.pid instead of 0 for the process.kill call in t2.js, as that allows the test suite to run to completion when invoked from the Makefile in the project root directory.
