### PR TITLE
Fix __diff_deeply Equivalence Equation

### DIFF
--- a/lib/trial/test.js
+++ b/lib/trial/test.js
@@ -217,8 +217,8 @@ function __diff_deeply(ctx,a,b,tolerance) {
       return null;
     case 'number':
       if(a == 0 && b ==0) return null
-      if(a!=0 && ((a-b)/a) <= tolerance) return null;
-      if(((a-b)/b) <= tolerance) return null;
+      if(a!=0 && Math.abs(((a-b)/a)) <= tolerance) return null;
+      if(Math.abs(((a-b)/b)) <= tolerance) return null;
       return __descdiff(ctx,a,b);
     case 'array':
       if(a.length != b.length)


### PR DESCRIPTION
We need to use the absolute value of these calculations to
correctly determine if two values are equivalent within a
tolerance.
