### PR TITLE
Fix For Low Floating-Point Numbers

### DIFF
--- a/lib/trial/test.js
+++ b/lib/trial/test.js
@@ -216,7 +216,12 @@ function __diff_deeply(ctx,a,b,tolerance) {
       if(a!=b) return __descdiff(ctx,a,b);
       return null;
     case 'number':
-      if(a == 0 && b ==0) return null
+      if(a == 0 && b == 0) return null;
+      //if the absolute value of both of these numbers is within a millionth,
+      //we're within the range that floating point math is inaccurate... we're 
+      //very close to zero as well, so the tolerance values could get wonky...
+      //just return that they are equal
+      if((Math.abs(a) < 0.000001) && (Math.abs(b) < 0.000001)) return null;
       if(a!=0 && Math.abs(((a-b)/a)) <= tolerance) return null;
       if(Math.abs(((a-b)/b)) <= tolerance) return null;
       return __descdiff(ctx,a,b);


### PR DESCRIPTION
There was a bug in the floating point number comparison when
values were close to zero (or actually equal to zero). The tolerance
values don't work right when one of the values is zero, or the two
numbers are both so low that percentage comparisons aren't useful.

Therefore - if the absolute value of any two numbers being compared
are each below a millionth, return that they are equal.
